### PR TITLE
Fix issue with LazyImage component getting stuck in English fallback …

### DIFF
--- a/overlay/src/components/lazy_image.vue
+++ b/overlay/src/components/lazy_image.vue
@@ -22,6 +22,7 @@ export default {
   watch: {
     src: function() {
       this.loaded = false
+      this.fallback = false
     },
   },
 }


### PR DESCRIPTION
…state

When the LazyImage component fails to load a localized card image it sets the fallback state to true and attempts the load the English version of the card. This state is not being reset when the card property changes which causes all subsequent image loads to be in English as well.